### PR TITLE
Split out install modes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,10 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: "3.9"
-    - run: mkdir example
+    - name: Prepare
+      run: |
+        mkdir example
+        echo ".venv/bin" >> $GITHUB_PATH
     # TODO test failure modes?
     - name: Create
       working-directory: example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,32 @@ jobs:
     - run: pip install poetry
     - run: poetry install
     - run: ./scripts/test
+  test-install:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.9"
+    - run: mkdir example
+    # TODO test failure modes?
+    - name: Create
+      workdir: example
+      run: |
+        cat ../barrel/install.py | python - combine==2.2.1
+        grep "combine==2.2.1" requirements.txt
+    - name: Update
+      workdir: example
+      run: |
+        cat ../barrel/install.py | python - combine==2.3.0 --update
+        grep "combine==2.3.0" requirements.txt
+    - name: Install
+      workdir: example
+      run: |
+        rm -r .venv
+        cat ../barrel/install.py | python - combine
+        grep "combine==2.3.0" requirements.txt
+    - name: Reinstall
+      workdir: example
+      run: |
+        cat ../barrel/install.py | python - combine --reinstall

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,22 +26,22 @@ jobs:
     - run: mkdir example
     # TODO test failure modes?
     - name: Create
-      workdir: example
+      working-directory: example
       run: |
         cat ../barrel/install.py | python - combine==2.2.1
         grep "combine==2.2.1" requirements.txt
     - name: Update
-      workdir: example
+      working-directory: example
       run: |
         cat ../barrel/install.py | python - combine==2.3.0 --update
         grep "combine==2.3.0" requirements.txt
     - name: Install
-      workdir: example
+      working-directory: example
       run: |
         rm -r .venv
         cat ../barrel/install.py | python - combine
         grep "combine==2.3.0" requirements.txt
     - name: Reinstall
-      workdir: example
+      working-directory: example
       run: |
         cat ../barrel/install.py | python - combine --reinstall

--- a/barrel/core.py
+++ b/barrel/core.py
@@ -1,6 +1,6 @@
 from .install import Installer
 
 
-def update(package_name: str, entrypoint_name: str = ""):
+def update(package_name: str, entrypoint_name: str = "") -> None:
     installer = Installer(package=package_name, entrypoint_name=entrypoint_name)
-    installer.install(reinstall=True)
+    installer.update()

--- a/barrel/install.py
+++ b/barrel/install.py
@@ -19,42 +19,82 @@ class Installer:
     VENV_NAME = ".venv"
     REQUIREMENTS_FILE = "requirements.txt"
 
-    def __init__(self, package: str, entrypoint_name: str = "", debug: bool = False):
+    # Installation modes
+    MODE_CREATE = "create"
+    MODE_INSTALL = "install"
+    MODE_UPDATE = "update"
+    MODE_REINSTALL = "reinstall"
+
+    def __init__(
+        self, package: str, entrypoint_name: str = "", debug: bool = False
+    ) -> None:
         self.package_input = package
         self.debug = debug
-        self.package_name, self.package_constraint = self.parse_package_input(
-            self.package_input
-        )
+        self.package_name = self.parse_package_name(self.package_input)
         self.entrypoint_name = entrypoint_name or self.package_name
 
-    def parse_package_input(self, package_input: str):
+    def parse_package_name(self, package_input: str) -> str:
+        package_name = ""
+
         package_parts = re.split(r"(?<!\\)[><~^=]", package_input)
         if len(package_parts) == 1:
             package_name = package_parts[0]
             if "/" in package_name:
                 # Quick way to account for paths right now...
                 package_name = package_name.split("/")[-1]
-            package_constraint = None
         else:
             package_name = package_parts[0]
-            package_constraint = package_parts[1]
-            package_constraint = package_constraint.replace("\\", "")
 
-        return package_name, package_constraint
+        return package_name
 
-    def install(self, reinstall: bool = False):
-        self.check_compatibility(reinstalling=reinstall)
+    def get_mode(self, reinstall: bool, update: bool) -> str:
+        if self.in_venv():
+            # This is the case when running `<package> update`
+            # for example, from inside a CLI using Barrel
+            return self.MODE_UPDATE
 
-        self.event(f"Installing {self.package_input} into this directory")
+        venv_exists = os.path.exists(self.VENV_NAME)
+        requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
 
-        if not self.in_venv() and self.has_existing():
-            if reinstall:
-                self.remove_existing()
+        if not venv_exists and not requirements_exists:
+            return self.MODE_CREATE
+
+        if requirements_exists and not venv_exists:
+            return self.MODE_INSTALL
+
+        if not requirements_exists and venv_exists:
+            self.error(
+                f"A {self.VENV_NAME} exists but {self.REQUIREMENTS_FILE} does not... might not be a Barrel-compatible installation?"
+            )
+            raise Abort()
+
+        if requirements_exists and venv_exists:
+            if update:
+                return self.MODE_UPDATE
+            elif reinstall:
+                return self.MODE_REINSTALL
             else:
-                self.error(
-                    f"Use --reinstall to overwrite the existing {self.VENV_NAME} and {self.REQUIREMENTS_FILE}"
-                )
+                self.error(f"Use --reinstall or --update in an existing installation")
                 raise Abort()
+
+        return self.MODE_INSTALL
+
+    def run(self, reinstall: bool = False, update: bool = False) -> None:
+        mode = self.get_mode(reinstall=reinstall, update=update)
+
+        if mode == self.MODE_CREATE:
+            self.install()
+        elif mode == self.MODE_INSTALL:
+            self.install()
+        elif mode == self.MODE_UPDATE:
+            self.update()
+        elif mode == self.MODE_REINSTALL:
+            self.reinstall()
+
+    def create(self) -> None:
+        """Creates .venv and requirements.txt"""
+        self.preflight(requirements_should_exist=False)
+        self.event(f"Setting up {self.package_input} in this directory")
 
         self.create_venv()
         self.pip_install()
@@ -62,16 +102,55 @@ class Installer:
         package_installed = self.get_installed_package()
 
         if not package_installed:
-            self.error(f"Could not find a pinned version of {package}")
+            self.error(f"Could not find a pinned version of {self.package_name}")
             raise Abort()
 
         self.save_requirements(package_installed)
+
         self.check_path()
         self.check_gitignore()
 
         self.success(f"\nSuccessfully installed {package_installed}!")
 
-    def check_compatibility(self, reinstalling):
+    def install(self) -> None:
+        """Installs existing requirements.txt"""
+        self.preflight(requirements_should_exist=True)
+        self.event(f"Installing {self.package_input} into this directory")
+
+        self.create_venv()
+        self.pip_install_requirements()
+
+        package_installed = self.get_installed_package()
+
+        self.check_path()
+        self.check_gitignore()
+
+        self.success(f"\nSuccessfully installed {package_installed}!")
+
+    def reinstall(self) -> None:
+        self.preflight(requirements_should_exist=False)
+        self.event(f"Re-installing {self.package_input} into this directory")
+
+        self.remove_existing()
+        self.create()
+
+    def update(self) -> None:
+        self.preflight(requirements_should_exist=True)
+        self.event(f"Updating {self.package_input}")
+
+        self.pip_update()
+
+        package_installed = self.get_installed_package()
+
+        if not package_installed:
+            self.error(f"Could not find a pinned version of {self.package_name}")
+            raise Abort()
+
+        self.save_requirements(package_installed)
+
+        self.success(f"\nSuccessfully updated {package_installed}!")
+
+    def preflight(self, requirements_should_exist: bool) -> None:
         if os.path.exists("pyproject.toml") or os.path.exists("poetry.lock"):
             print(
                 "It looks like you are using Poetry for dependencies. Use the `poetry update` command instead."
@@ -96,41 +175,26 @@ class Installer:
             )
             raise Abort()
 
-        if reinstalling and not os.path.exists(Installer.REQUIREMENTS_FILE):
+        if requirements_should_exist and not os.path.exists(
+            Installer.REQUIREMENTS_FILE
+        ):
             print(
-                f"A {Installer.REQUIREMENTS_FILE} file does not exist, which likely means that you aren't updating a barrel-compatible installation or aren't in the right directory."
+                f"A {self.REQUIREMENTS_FILE} file does not exist, which likely means that you aren't updating a barrel-compatible installation or aren't in the right directory."
             )
             raise Abort()
 
-    def in_venv(self):
+    def in_venv(self) -> bool:
         return sys.executable.startswith(os.path.abspath(self.VENV_NAME) + os.sep)
 
-    def entrypoint_available(self):
+    def entrypoint_available(self) -> bool:
         which = shutil.which(self.entrypoint_name)
         if not which:
             return False
+
         rel = os.path.relpath(which)
         return rel.startswith(self.VENV_NAME)
 
-    def has_existing(self):
-        venv_exists = os.path.exists(self.VENV_NAME)
-        requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
-
-        if venv_exists or requirements_exists:
-            if venv_exists and requirements_exists:
-                self.warn(
-                    f"- Both a virtual environment ({self.VENV_NAME}) and a requirements file ({self.REQUIREMENTS_FILE}) already exist"
-                )
-            elif venv_exists:
-                self.warn(f"- A virtual environment ({self.VENV_NAME}) already exists")
-            elif requirements_exists:
-                self.warn(
-                    f"- A requirements file ({self.REQUIREMENTS_FILE}) already exists"
-                )
-
-            return True
-
-    def remove_existing(self):
+    def remove_existing(self) -> None:
         venv_exists = os.path.exists(self.VENV_NAME)
         requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
 
@@ -142,18 +206,32 @@ class Installer:
             self.event(f"  - Removing existing {self.REQUIREMENTS_FILE}")
             os.remove(self.REQUIREMENTS_FILE)
 
-    def create_venv(self):
+    def create_venv(self) -> None:
         self.event(f"- Creating a virtual environment at {self.VENV_NAME}")
         subprocess.check_call([sys.executable, "-m", "venv", self.VENV_NAME])
 
-    def pip_install(self):
+    def pip_install(self) -> None:
         self.event(f"- Installing {self.package_input} with {self.VENV_NAME}/bin/pip")
         subprocess.check_call(
             [f"{self.VENV_NAME}/bin/pip", "install", self.package_input],
             stdout=sys.stdout if self.debug else subprocess.DEVNULL,
         )
 
-    def save_requirements(self, package_installed: str):
+    def pip_install_requirements(self) -> None:
+        self.event(f"- Installing {self.REQUIREMENTS_FILE}")
+        subprocess.check_call(
+            [f"{self.VENV_NAME}/bin/pip", "install", "-r", self.REQUIREMENTS_FILE],
+            stdout=sys.stdout if self.debug else subprocess.DEVNULL,
+        )
+
+    def pip_update(self) -> None:
+        self.event(f"- Updating {self.package_input} with {self.VENV_NAME}/bin/pip")
+        subprocess.check_call(
+            [f"{self.VENV_NAME}/bin/pip", "install", "-U", self.package_input],
+            stdout=sys.stdout if self.debug else subprocess.DEVNULL,
+        )
+
+    def save_requirements(self, package_installed: str) -> None:
         self.event(f"- Saving {self.REQUIREMENTS_FILE}")
         with open(self.REQUIREMENTS_FILE, "w+") as f:
             f.write(f"# This file is managed automatically by {self.package_name}\n")
@@ -162,14 +240,14 @@ class Installer:
             # as part of the point of this is to *simplify* the process
             # (the downside to this is that transitive dependencies can and will change without notice)
 
-    def check_path(self):
+    def check_path(self) -> None:
         if not self.entrypoint_available():
             self.error(
                 f'Could not find {self.package_name} in PATH\n\nAn simple solution is to add this to your .bash_profile/.zshrc:\nexport PATH="./.venv/bin:$PATH"'
             )
             raise Abort()
 
-    def check_gitignore(self):
+    def check_gitignore(self) -> None:
         if (
             os.path.exists(".git")
             and not self.gitignore_contains(self.VENV_NAME)
@@ -179,7 +257,7 @@ class Installer:
                 f"- You should add {self.VENV_NAME} to your .gitignore so that it is not tracked by git"
             )
 
-    def gitignore_contains(self, text: str):
+    def gitignore_contains(self, text: str) -> bool:
         if not os.path.exists(".gitignore"):
             return False
 
@@ -190,7 +268,7 @@ class Installer:
 
         return False
 
-    def get_installed_package(self):
+    def get_installed_package(self) -> str:
         for line in (
             subprocess.check_output([f"{self.VENV_NAME}/bin/pip", "freeze"])
             .decode("utf-8")
@@ -199,23 +277,25 @@ class Installer:
             if re.match(r"^{}\W+".format(self.package_name), line.lower()):
                 return line
 
-    def confirm(self, prompt: str):
+        return ""
+
+    def confirm(self, prompt: str) -> bool:
         return "y" in input(prompt).lower()
 
-    def event(self, text: str):
+    def event(self, text: str) -> None:
         """Print in bold if we're in deubg (so regular output is distinguished)"""
         if self.debug:
             print("\033[1m" + text + "\033[0m")
         else:
             print(text)
 
-    def warn(self, text: str):
+    def warn(self, text: str) -> None:
         print("\033[33m" + text + "\033[0m")
 
-    def error(self, text: str):
+    def error(self, text: str) -> None:
         print("\033[31m" + text + "\033[0m")
 
-    def success(self, text: str):
+    def success(self, text: str) -> None:
         print("\033[32m" + text + "\033[0m")
 
 
@@ -234,6 +314,12 @@ if __name__ == "__main__":
     else:
         reinstall = False
 
+    if "--update" in sys.argv:
+        sys.argv.remove("--update")
+        update = True
+    else:
+        update = False
+
     if "--debug" in sys.argv:
         sys.argv.remove("--debug")
         debug = True
@@ -251,6 +337,6 @@ if __name__ == "__main__":
 
     installer = Installer(package=package, entrypoint_name=entrypoint_name, debug=debug)
     try:
-        installer.install(reinstall=reinstall)
+        installer.run(reinstall=reinstall, update=update)
     except Abort:
         sys.exit(1)

--- a/barrel/install.py
+++ b/barrel/install.py
@@ -83,7 +83,7 @@ class Installer:
         mode = self.get_mode(reinstall=reinstall, update=update)
 
         if mode == self.MODE_CREATE:
-            self.install()
+            self.create()
         elif mode == self.MODE_INSTALL:
             self.install()
         elif mode == self.MODE_UPDATE:

--- a/barrel/install.py
+++ b/barrel/install.py
@@ -138,7 +138,12 @@ class Installer:
         self.preflight(requirements_should_exist=True)
         self.event(f"Updating {self.package_input}")
 
-        self.pip_update()
+        if self.package_name == self.package_input:
+            # Just update to latest
+            self.pip_update()
+        else:
+            # Could be specifying a version
+            self.pip_install()
 
         package_installed = self.get_installed_package()
 

--- a/scripts/test
+++ b/scripts/test
@@ -4,4 +4,5 @@ poetry run mypy barrel
 echo "Making sure site install.py is latest (currently latest on master, not latest from release)"
 if ! diff barrel/install.py site/content/install.py; then
     echo "Do 'cp barrel/install.py site/content/install.py' to update"
+    exit 1
 fi

--- a/site/content/install.py
+++ b/site/content/install.py
@@ -19,42 +19,82 @@ class Installer:
     VENV_NAME = ".venv"
     REQUIREMENTS_FILE = "requirements.txt"
 
-    def __init__(self, package: str, entrypoint_name: str = "", debug: bool = False):
+    # Installation modes
+    MODE_CREATE = "create"
+    MODE_INSTALL = "install"
+    MODE_UPDATE = "update"
+    MODE_REINSTALL = "reinstall"
+
+    def __init__(
+        self, package: str, entrypoint_name: str = "", debug: bool = False
+    ) -> None:
         self.package_input = package
         self.debug = debug
-        self.package_name, self.package_constraint = self.parse_package_input(
-            self.package_input
-        )
+        self.package_name = self.parse_package_name(self.package_input)
         self.entrypoint_name = entrypoint_name or self.package_name
 
-    def parse_package_input(self, package_input: str):
+    def parse_package_name(self, package_input: str) -> str:
+        package_name = ""
+
         package_parts = re.split(r"(?<!\\)[><~^=]", package_input)
         if len(package_parts) == 1:
             package_name = package_parts[0]
             if "/" in package_name:
                 # Quick way to account for paths right now...
                 package_name = package_name.split("/")[-1]
-            package_constraint = None
         else:
             package_name = package_parts[0]
-            package_constraint = package_parts[1]
-            package_constraint = package_constraint.replace("\\", "")
 
-        return package_name, package_constraint
+        return package_name
 
-    def install(self, reinstall: bool = False):
-        self.check_compatibility(reinstalling=reinstall)
+    def get_mode(self, reinstall: bool, update: bool) -> str:
+        if self.in_venv():
+            # This is the case when running `<package> update`
+            # for example, from inside a CLI using Barrel
+            return self.MODE_UPDATE
 
-        self.event(f"Installing {self.package_input} into this directory")
+        venv_exists = os.path.exists(self.VENV_NAME)
+        requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
 
-        if not self.in_venv() and self.has_existing():
-            if reinstall:
-                self.remove_existing()
+        if not venv_exists and not requirements_exists:
+            return self.MODE_CREATE
+
+        if requirements_exists and not venv_exists:
+            return self.MODE_INSTALL
+
+        if not requirements_exists and venv_exists:
+            self.error(
+                f"A {self.VENV_NAME} exists but {self.REQUIREMENTS_FILE} does not... might not be a Barrel-compatible installation?"
+            )
+            raise Abort()
+
+        if requirements_exists and venv_exists:
+            if update:
+                return self.MODE_UPDATE
+            elif reinstall:
+                return self.MODE_REINSTALL
             else:
-                self.error(
-                    f"Use --reinstall to overwrite the existing {self.VENV_NAME} and {self.REQUIREMENTS_FILE}"
-                )
+                self.error(f"Use --reinstall or --update in an existing installation")
                 raise Abort()
+
+        return self.MODE_INSTALL
+
+    def run(self, reinstall: bool = False, update: bool = False) -> None:
+        mode = self.get_mode(reinstall=reinstall, update=update)
+
+        if mode == self.MODE_CREATE:
+            self.install()
+        elif mode == self.MODE_INSTALL:
+            self.install()
+        elif mode == self.MODE_UPDATE:
+            self.update()
+        elif mode == self.MODE_REINSTALL:
+            self.reinstall()
+
+    def create(self) -> None:
+        """Creates .venv and requirements.txt"""
+        self.preflight(requirements_should_exist=False)
+        self.event(f"Setting up {self.package_input} in this directory")
 
         self.create_venv()
         self.pip_install()
@@ -62,16 +102,55 @@ class Installer:
         package_installed = self.get_installed_package()
 
         if not package_installed:
-            self.error(f"Could not find a pinned version of {package}")
+            self.error(f"Could not find a pinned version of {self.package_name}")
             raise Abort()
 
         self.save_requirements(package_installed)
+
         self.check_path()
         self.check_gitignore()
 
         self.success(f"\nSuccessfully installed {package_installed}!")
 
-    def check_compatibility(self, reinstalling):
+    def install(self) -> None:
+        """Installs existing requirements.txt"""
+        self.preflight(requirements_should_exist=True)
+        self.event(f"Installing {self.package_input} into this directory")
+
+        self.create_venv()
+        self.pip_install_requirements()
+
+        package_installed = self.get_installed_package()
+
+        self.check_path()
+        self.check_gitignore()
+
+        self.success(f"\nSuccessfully installed {package_installed}!")
+
+    def reinstall(self) -> None:
+        self.preflight(requirements_should_exist=False)
+        self.event(f"Re-installing {self.package_input} into this directory")
+
+        self.remove_existing()
+        self.create()
+
+    def update(self) -> None:
+        self.preflight(requirements_should_exist=True)
+        self.event(f"Updating {self.package_input}")
+
+        self.pip_update()
+
+        package_installed = self.get_installed_package()
+
+        if not package_installed:
+            self.error(f"Could not find a pinned version of {self.package_name}")
+            raise Abort()
+
+        self.save_requirements(package_installed)
+
+        self.success(f"\nSuccessfully updated {package_installed}!")
+
+    def preflight(self, requirements_should_exist: bool) -> None:
         if os.path.exists("pyproject.toml") or os.path.exists("poetry.lock"):
             print(
                 "It looks like you are using Poetry for dependencies. Use the `poetry update` command instead."
@@ -96,41 +175,26 @@ class Installer:
             )
             raise Abort()
 
-        if reinstalling and not os.path.exists(Installer.REQUIREMENTS_FILE):
+        if requirements_should_exist and not os.path.exists(
+            Installer.REQUIREMENTS_FILE
+        ):
             print(
-                f"A {Installer.REQUIREMENTS_FILE} file does not exist, which likely means that you aren't updating a barrel-compatible installation or aren't in the right directory."
+                f"A {self.REQUIREMENTS_FILE} file does not exist, which likely means that you aren't updating a barrel-compatible installation or aren't in the right directory."
             )
             raise Abort()
 
-    def in_venv(self):
+    def in_venv(self) -> bool:
         return sys.executable.startswith(os.path.abspath(self.VENV_NAME) + os.sep)
 
-    def entrypoint_available(self):
+    def entrypoint_available(self) -> bool:
         which = shutil.which(self.entrypoint_name)
         if not which:
             return False
+
         rel = os.path.relpath(which)
         return rel.startswith(self.VENV_NAME)
 
-    def has_existing(self):
-        venv_exists = os.path.exists(self.VENV_NAME)
-        requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
-
-        if venv_exists or requirements_exists:
-            if venv_exists and requirements_exists:
-                self.warn(
-                    f"- Both a virtual environment ({self.VENV_NAME}) and a requirements file ({self.REQUIREMENTS_FILE}) already exist"
-                )
-            elif venv_exists:
-                self.warn(f"- A virtual environment ({self.VENV_NAME}) already exists")
-            elif requirements_exists:
-                self.warn(
-                    f"- A requirements file ({self.REQUIREMENTS_FILE}) already exists"
-                )
-
-            return True
-
-    def remove_existing(self):
+    def remove_existing(self) -> None:
         venv_exists = os.path.exists(self.VENV_NAME)
         requirements_exists = os.path.exists(self.REQUIREMENTS_FILE)
 
@@ -142,18 +206,32 @@ class Installer:
             self.event(f"  - Removing existing {self.REQUIREMENTS_FILE}")
             os.remove(self.REQUIREMENTS_FILE)
 
-    def create_venv(self):
+    def create_venv(self) -> None:
         self.event(f"- Creating a virtual environment at {self.VENV_NAME}")
         subprocess.check_call([sys.executable, "-m", "venv", self.VENV_NAME])
 
-    def pip_install(self):
+    def pip_install(self) -> None:
         self.event(f"- Installing {self.package_input} with {self.VENV_NAME}/bin/pip")
         subprocess.check_call(
             [f"{self.VENV_NAME}/bin/pip", "install", self.package_input],
             stdout=sys.stdout if self.debug else subprocess.DEVNULL,
         )
 
-    def save_requirements(self, package_installed: str):
+    def pip_install_requirements(self) -> None:
+        self.event(f"- Installing {self.REQUIREMENTS_FILE}")
+        subprocess.check_call(
+            [f"{self.VENV_NAME}/bin/pip", "install", "-r", self.REQUIREMENTS_FILE],
+            stdout=sys.stdout if self.debug else subprocess.DEVNULL,
+        )
+
+    def pip_update(self) -> None:
+        self.event(f"- Updating {self.package_input} with {self.VENV_NAME}/bin/pip")
+        subprocess.check_call(
+            [f"{self.VENV_NAME}/bin/pip", "install", "-U", self.package_input],
+            stdout=sys.stdout if self.debug else subprocess.DEVNULL,
+        )
+
+    def save_requirements(self, package_installed: str) -> None:
         self.event(f"- Saving {self.REQUIREMENTS_FILE}")
         with open(self.REQUIREMENTS_FILE, "w+") as f:
             f.write(f"# This file is managed automatically by {self.package_name}\n")
@@ -162,14 +240,14 @@ class Installer:
             # as part of the point of this is to *simplify* the process
             # (the downside to this is that transitive dependencies can and will change without notice)
 
-    def check_path(self):
+    def check_path(self) -> None:
         if not self.entrypoint_available():
             self.error(
                 f'Could not find {self.package_name} in PATH\n\nAn simple solution is to add this to your .bash_profile/.zshrc:\nexport PATH="./.venv/bin:$PATH"'
             )
             raise Abort()
 
-    def check_gitignore(self):
+    def check_gitignore(self) -> None:
         if (
             os.path.exists(".git")
             and not self.gitignore_contains(self.VENV_NAME)
@@ -179,7 +257,7 @@ class Installer:
                 f"- You should add {self.VENV_NAME} to your .gitignore so that it is not tracked by git"
             )
 
-    def gitignore_contains(self, text: str):
+    def gitignore_contains(self, text: str) -> bool:
         if not os.path.exists(".gitignore"):
             return False
 
@@ -190,7 +268,7 @@ class Installer:
 
         return False
 
-    def get_installed_package(self):
+    def get_installed_package(self) -> str:
         for line in (
             subprocess.check_output([f"{self.VENV_NAME}/bin/pip", "freeze"])
             .decode("utf-8")
@@ -199,23 +277,25 @@ class Installer:
             if re.match(r"^{}\W+".format(self.package_name), line.lower()):
                 return line
 
-    def confirm(self, prompt: str):
+        return ""
+
+    def confirm(self, prompt: str) -> bool:
         return "y" in input(prompt).lower()
 
-    def event(self, text: str):
+    def event(self, text: str) -> None:
         """Print in bold if we're in deubg (so regular output is distinguished)"""
         if self.debug:
             print("\033[1m" + text + "\033[0m")
         else:
             print(text)
 
-    def warn(self, text: str):
+    def warn(self, text: str) -> None:
         print("\033[33m" + text + "\033[0m")
 
-    def error(self, text: str):
+    def error(self, text: str) -> None:
         print("\033[31m" + text + "\033[0m")
 
-    def success(self, text: str):
+    def success(self, text: str) -> None:
         print("\033[32m" + text + "\033[0m")
 
 
@@ -234,6 +314,12 @@ if __name__ == "__main__":
     else:
         reinstall = False
 
+    if "--update" in sys.argv:
+        sys.argv.remove("--update")
+        update = True
+    else:
+        update = False
+
     if "--debug" in sys.argv:
         sys.argv.remove("--debug")
         debug = True
@@ -251,6 +337,6 @@ if __name__ == "__main__":
 
     installer = Installer(package=package, entrypoint_name=entrypoint_name, debug=debug)
     try:
-        installer.install(reinstall=reinstall)
+        installer.run(reinstall=reinstall, update=update)
     except Abort:
         sys.exit(1)

--- a/site/content/install.py
+++ b/site/content/install.py
@@ -83,7 +83,7 @@ class Installer:
         mode = self.get_mode(reinstall=reinstall, update=update)
 
         if mode == self.MODE_CREATE:
-            self.install()
+            self.create()
         elif mode == self.MODE_INSTALL:
             self.install()
         elif mode == self.MODE_UPDATE:

--- a/site/content/install.py
+++ b/site/content/install.py
@@ -138,7 +138,12 @@ class Installer:
         self.preflight(requirements_should_exist=True)
         self.event(f"Updating {self.package_input}")
 
-        self.pip_update()
+        if self.package_name == self.package_input:
+            # Just update to latest
+            self.pip_update()
+        else:
+            # Could be specifying a version
+            self.pip_install()
 
         package_installed = self.get_installed_package()
 


### PR DESCRIPTION
Needs to be tested, but this splits out the modes and adds a standard "install" (w/o update) which would be the case if you cloned a repo and had `requirements.txt` but not `.venv`.